### PR TITLE
Update network - fixed - missing lan/wan/br-lan

### DIFF
--- a/network
+++ b/network
@@ -1,92 +1,114 @@
-
 config interface 'loopback'
-	option device 'lo'
-	option proto 'static'
-	option ipaddr '127.0.0.1'
-	option netmask '255.0.0.0'
+        option device 'lo'
+        option proto 'static'
+        option ipaddr '127.0.0.1'
+        option netmask '255.0.0.0'
+
+config globals 'globals'
+        option ula_prefix 'fdd0:66e1:6c49::/48'
 
 config device
-	option type '8021q'
-	option ifname 'eth0'
-	option vid '1'
-	option name 'vlan1'
+        option name 'br-lan'
+        option type 'bridge'
+        list ports 'vlan2'
+        list ports 'vlan3'
+        list ports 'vlan4'
+        list ports 'vlan5'
+        list ports 'vlan6'
+        list ports 'vlan7'
+        list ports 'vlan8'
+
+config interface 'lan'
+        option device 'br-lan'
+        option proto 'static'
+        option ipaddr '192.168.1.1'
+        option netmask '255.255.255.0'
+        option ip6assign '60'
+
+config interface 'wan'
+        option device 'vlan1'
+        option proto 'dhcp'
+        
+config interface 'wan6'
+        option device 'vlan1'
+        option proto 'dhcpv6'
 
 config device
-	option type '8021q'
-	option ifname 'eth0'
-	option vid '2'
-	option name 'vlan2'
+        option type '8021q'
+        option ifname 'eth0'
+        option vid '1'
+        option name 'vlan1'
 
 config device
-	option type '8021q'
-	option ifname 'eth0'
-	option vid '3'
-	option name 'vlan3'
+        option type '8021q'
+        option ifname 'eth0'
+        option vid '2'
+        option name 'vlan2'
 
 config device
-	option type '8021q'
-	option ifname 'eth0'
-	option vid '4'
-	option name 'vlan4'
+        option type '8021q'
+        option ifname 'eth0'
+        option vid '3'
+        option name 'vlan3'
 
 config device
-	option type '8021q'
-	option ifname 'eth0'
-	option vid '5'
-	option name 'vlan5'
+        option type '8021q'
+        option ifname 'eth0'
+        option vid '4'
+        option name 'vlan4'
 
 config device
-	option type '8021q'
-	option ifname 'eth0'
-	option vid '6'
-	option name 'vlan6'
+        option type '8021q'
+        option ifname 'eth0'
+        option vid '5'
+        option name 'vlan5'
 
 config device
-	option type '8021q'
-	option ifname 'eth0'
-	option vid '7'
-	option name 'vlan7'
+        option type '8021q'
+        option ifname 'eth0'
+        option vid '6'
+        option name 'vlan6'
 
 config device
-	option type '8021q'
-	option ifname 'eth0'
-	option vid '8'
-	option name 'vlan8'
+        option type '8021q'
+        option ifname 'eth0'
+        option vid '7'
+        option name 'vlan7'
 
+config device
+        option type '8021q'
+        option ifname 'eth0'
+        option vid '8'
+        option name 'vlan8'
+        
 config interface 'port01'
-	option proto 'static'
-	option device 'vlan1'
-	option ipaddr 'YOUR-IP'
-	option netmask 'YOUR-NETMASK'
-	option gateway 'YOUR-GATEWAY'
-	list dns 'YOUR-DNS'
+        #option proto 'dhcp'
+        option device 'vlan1'
 
 config interface 'port02'
-	option proto 'dhcp'
-	option device 'vlan2'
+        option proto 'dhcp'
+        option device 'vlan2'
 
 config interface 'port03'
-	option proto 'dhcp'
-	option device 'vlan3'
+        option proto 'dhcp'
+        option device 'vlan3'
 
 config interface 'port04'
-	option proto 'dhcp'
-	option device 'vlan4'
+        option proto 'dhcp'
+        option device 'vlan4'
 
 config interface 'port05'
-	option proto 'dhcp'
-	option device 'vlan5'
+        option proto 'dhcp'
+        option device 'vlan5'
 
 config interface 'port06'
-	option proto 'dhcp'
-	option device 'vlan6'
+        option proto 'dhcp'
+        option device 'vlan6'
 
 config interface 'port07'
-	option proto 'dhcp'
-	option device 'vlan7'
-
+        option proto 'dhcp'
+        option device 'vlan7'
+        
 config interface 'port08'
-	option proto 'dhcp'
-	option device 'vlan8'
-
-
+        option proto 'dhcp'
+        option device 'vlan8'


### PR DESCRIPTION
Original network file showed the 1+7 device/port config via separate VLANs only. That results a router with one incoming DHCP IP and seven other ports with nothing:

- Added/fixed br-lan (vlan2-8)
- Added: lan (br-lan), wan(vlan1), wan6(vlan1)
- with such config however not the finest, all elements works -> DCHP on local lan ports, wan IP, FW

*Not sure what way would be better to have all the 8 network ports live separately, will check the original FW with NS-BSD, how is it doing